### PR TITLE
Bootstrap Prompt Maestro desktop studio scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# traza
+# Prompt Maestro (base técnica)
+
+Base inicial para una app desktop de producción de KVs retail con:
+
+- Electron + React + TypeScript
+- Canvas con Konva
+- Estructura de 3 paneles (assets/prompt, canvas, propiedades)
+- Modelo de capas editable para flujo: **Final / Fondo / Producto**
+
+## Ejecutar
+
+```bash
+npm install
+npm run dev
+```
+
+## Estado actual
+
+Este commit deja un esqueleto funcional con:
+
+1. Carga de archivos (referencias, PNG, fuentes) en panel izquierdo.
+2. Prompt IA (interfaz preparada para integrar OpenAI/Stability).
+3. Canvas editable con drag en capas base.
+4. Panel de propiedades para editar posición y tamaño.
+5. Arquitectura de store global con Zustand para extender reglas de branding, locks y export editable.
+
+## Próximos pasos sugeridos
+
+- Integrar `ag-psd` para export PSD por capas.
+- Añadir bloqueo por metadatos (`locked`, `deformable`, `minScale`, `maxScale`).
+- Implementar `Typography Manager` con carga de TTF/OTF real y uso por rol.
+- Export multi-formato (16:9, 1:1, 4:5, 9:16) con safe areas.
+- Motor de reglas visuales por marca.

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,0 +1,21 @@
+const { app, BrowserWindow } = require('electron');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1440,
+    height: 900,
+    minWidth: 1200,
+    minHeight: 760,
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false
+    }
+  });
+
+  win.loadURL('http://localhost:5173');
+}
+
+app.whenReady().then(createWindow);
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Prompt Maestro</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "prompt-maestro",
+  "version": "0.1.0",
+  "private": true,
+  "main": "electron/main.js",
+  "scripts": {
+    "dev": "concurrently \"vite\" \"wait-on tcp:5173 && electron .\"",
+    "build": "vite build",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "konva": "^9.3.16",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-konva": "^18.2.10",
+    "zustand": "^4.5.5"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.1",
+    "@types/react": "^18.3.13",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "concurrently": "^9.1.0",
+    "typescript": "^5.7.2",
+    "vite": "^6.0.1",
+    "wait-on": "^8.0.1"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,13 @@
+import { CanvasPanel } from './components/CanvasPanel';
+import { LeftPanel } from './components/LeftPanel';
+import { RightPanel } from './components/RightPanel';
+
+export function App() {
+  return (
+    <div className="layout">
+      <LeftPanel />
+      <CanvasPanel />
+      <RightPanel />
+    </div>
+  );
+}

--- a/src/components/CanvasPanel.tsx
+++ b/src/components/CanvasPanel.tsx
@@ -1,0 +1,48 @@
+import { Stage, Layer, Rect, Text } from 'react-konva';
+import { useStudioStore } from '../store/useStudioStore';
+
+export function CanvasPanel() {
+  const layers = useStudioStore((s) => s.layers);
+  const selectedId = useStudioStore((s) => s.selectedId);
+  const selectLayer = useStudioStore((s) => s.selectLayer);
+  const updateLayer = useStudioStore((s) => s.updateLayer);
+
+  return (
+    <main className="canvasWrap">
+      <Stage width={1120} height={680} onMouseDown={() => selectLayer(undefined)}>
+        <Layer>
+          {layers.map((item) =>
+            item.kind === 'text' ? (
+              <Text
+                key={item.id}
+                text={item.text ?? item.name}
+                x={item.x}
+                y={item.y}
+                fontSize={52}
+                fill={item.color ?? '#fff'}
+                draggable={!item.locked}
+                onClick={() => selectLayer(item.id)}
+                onDragEnd={(e) => updateLayer(item.id, { x: e.target.x(), y: e.target.y() })}
+              />
+            ) : (
+              <Rect
+                key={item.id}
+                x={item.x}
+                y={item.y}
+                width={item.width}
+                height={item.height}
+                fill={item.kind === 'product' ? '#f59e0b' : '#334155'}
+                stroke={selectedId === item.id ? '#22d3ee' : '#64748b'}
+                strokeWidth={selectedId === item.id ? 3 : 1}
+                cornerRadius={8}
+                draggable={!item.locked}
+                onClick={() => selectLayer(item.id)}
+                onDragEnd={(e) => updateLayer(item.id, { x: e.target.x(), y: e.target.y() })}
+              />
+            )
+          )}
+        </Layer>
+      </Stage>
+    </main>
+  );
+}

--- a/src/components/LeftPanel.tsx
+++ b/src/components/LeftPanel.tsx
@@ -1,0 +1,24 @@
+import { useStudioStore } from '../store/useStudioStore';
+
+export function LeftPanel() {
+  const prompt = useStudioStore((s) => s.prompt);
+  const setPrompt = useStudioStore((s) => s.setPrompt);
+  return (
+    <aside className="panel">
+      <h3>Referencias + Prompt</h3>
+      <label className="label">Subir referencias</label>
+      <input type="file" multiple accept="image/*" />
+      <label className="label">Subir PNGs de producto</label>
+      <input type="file" multiple accept="image/png" />
+      <label className="label">Subir tipografías</label>
+      <input type="file" multiple accept=".otf,.ttf" />
+      <textarea
+        value={prompt}
+        onChange={(e) => setPrompt(e.target.value)}
+        placeholder="Ej: Regenera SOLO el fondo estilo verano tropical. No mover producto ni logo."
+        rows={7}
+      />
+      <button>Generar capas IA</button>
+    </aside>
+  );
+}

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1,0 +1,33 @@
+import { useStudioStore } from '../store/useStudioStore';
+
+export function RightPanel() {
+  const layers = useStudioStore((s) => s.layers);
+  const selectedId = useStudioStore((s) => s.selectedId);
+  const updateLayer = useStudioStore((s) => s.updateLayer);
+  const selected = layers.find((l) => l.id === selectedId);
+
+  return (
+    <aside className="panel">
+      <h3>Propiedades</h3>
+      {selected ? (
+        <>
+          <p><strong>{selected.name}</strong> ({selected.kind})</p>
+          <label className="label">X</label>
+          <input type="number" value={selected.x} onChange={(e) => updateLayer(selected.id, { x: Number(e.target.value) })} />
+          <label className="label">Y</label>
+          <input type="number" value={selected.y} onChange={(e) => updateLayer(selected.id, { y: Number(e.target.value) })} />
+          <label className="label">Ancho</label>
+          <input type="number" value={selected.width} onChange={(e) => updateLayer(selected.id, { width: Number(e.target.value) })} />
+          <label className="label">Alto</label>
+          <input type="number" value={selected.height} onChange={(e) => updateLayer(selected.id, { height: Number(e.target.value) })} />
+        </>
+      ) : <p>Selecciona una capa para editar.</p>}
+      <h4>Exportables objetivo</h4>
+      <ul>
+        <li>Imagen final</li>
+        <li>Fondo sin bodegón</li>
+        <li>Producto aislado</li>
+      </ul>
+    </aside>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './App';
+import './styles.css';
+
+createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/store/useStudioStore.ts
+++ b/src/store/useStudioStore.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand';
+import { CanvasLayer } from '../types';
+
+interface StudioState {
+  layers: CanvasLayer[];
+  selectedId?: string;
+  prompt: string;
+  addLayer: (layer: CanvasLayer) => void;
+  updateLayer: (id: string, patch: Partial<CanvasLayer>) => void;
+  selectLayer: (id?: string) => void;
+  setPrompt: (prompt: string) => void;
+}
+
+export const useStudioStore = create<StudioState>((set) => ({
+  layers: [
+    { id: 'bg-1', kind: 'background', name: 'Fondo base', x: 60, y: 60, width: 1000, height: 560 },
+    { id: 'txt-1', kind: 'text', name: 'Headline', x: 120, y: 100, width: 320, height: 80, text: 'NUEVO COMBO', fontFamily: 'Arial', color: '#ffffff' }
+  ],
+  prompt: '',
+  addLayer: (layer) => set((s) => ({ layers: [...s.layers, layer] })),
+  updateLayer: (id, patch) => set((s) => ({ layers: s.layers.map((l) => (l.id === id ? { ...l, ...patch } : l)) })),
+  selectLayer: (id) => set({ selectedId: id }),
+  setPrompt: (prompt) => set({ prompt })
+}));

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,9 @@
+:root { color-scheme: dark; }
+body { margin: 0; font-family: Inter, Arial, sans-serif; background: #0b1220; color: #e2e8f0; }
+.layout { display: grid; grid-template-columns: 320px 1fr 320px; height: 100vh; }
+.panel { border-right: 1px solid #1e293b; padding: 16px; display: flex; flex-direction: column; gap: 8px; background: #0f172a; }
+.panel:last-child { border-right: 0; border-left: 1px solid #1e293b; }
+.label { font-size: 12px; color: #94a3b8; }
+input, textarea, button { background: #111827; color: #e2e8f0; border: 1px solid #334155; border-radius: 8px; padding: 8px; }
+button { cursor: pointer; font-weight: 600; }
+.canvasWrap { display: flex; justify-content: center; align-items: center; overflow: auto; background: #020617; }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,16 @@
+export type LayerKind = 'final' | 'background' | 'product' | 'text' | 'logo' | 'props';
+
+export interface CanvasLayer {
+  id: string;
+  kind: LayerKind;
+  name: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  locked?: boolean;
+  src?: string;
+  text?: string;
+  fontFamily?: string;
+  color?: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({ plugins: [react()] });


### PR DESCRIPTION
### Motivation
- Provide a runnable desktop foundation for Prompt Maestro so iterative work on asset management, AI-assisted generation and editable layered exports can proceed.  
- Establish the three-panel studio workflow (references/prompt, canvas, properties) required for KV composition and partial regeneration features.  

### Description
- Initialized an Electron + React + TypeScript + Vite scaffold with `package.json`, `vite.config.ts`, and `electron/main.js` to run a desktop studio.  
- Added a three-panel UI with `src/components/LeftPanel.tsx`, `src/components/CanvasPanel.tsx`, and `src/components/RightPanel.tsx` plus `src/styles.css` and `index.html`, and integrated a Konva-based canvas for drag/select behavior.  
- Implemented a global Zustand store in `src/store/useStudioStore.ts` and a typed layer model in `src/types.ts` with sample layers and prompt state, and wired `src/main.tsx` and `src/App.tsx` to render the studio.  

### Testing
- Ran the TypeScript typecheck via `npm run lint` which failed due to missing installed dependencies and type definitions (`Cannot find type definition file for 'node'`), so run `npm install` first and then `npm run lint`.  
- No additional automated tests were present or executed in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09c6848c4083259c52d3fdcce62f74)